### PR TITLE
Static core library refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,46 +12,46 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Widgets)
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets)
 
+# Core library sources
+set(CORE_SOURCES
+    fish.h fish.cpp
+    shark.h shark.cpp
+    world.h world.cpp
+    creature.h creature.cpp
+    cell.h cell.cpp
+    creatureType.h
+    creaturefactory.h creaturefactory.cpp
+)
+
+# Create a static library for the core logic
+add_library(GameOfLifeCore STATIC ${CORE_SOURCES})
+
+# Main application sources
 set(PROJECT_SOURCES
-        main.cpp
-        mainwindow.cpp
-        mainwindow.h
-        mainwindow.ui
+    main.cpp
+    mainwindow.cpp
+    mainwindow.h
+    mainwindow.ui
+    settingswindow.h
+    settingswindow.cpp
+    settingswindow.ui
 )
 
 if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)
     qt_add_executable(GameOfLife
         MANUAL_FINALIZATION
         ${PROJECT_SOURCES}
-        fish.h fish.cpp
-        shark.h shark.cpp
-        world.h world.cpp
-        creature.h creature.cpp
-        cell.h cell.cpp
-        creatureType.h
-        creaturefactory.h creaturefactory.cpp
-        settingswindow.h settingswindow.cpp settingswindow.ui
     )
-
-# Define target properties for Android with Qt 6 as:
-#    set_property(TARGET GameOfLife APPEND PROPERTY QT_ANDROID_PACKAGE_SOURCE_DIR
-#                 ${CMAKE_CURRENT_SOURCE_DIR}/android)
-# For more information, see https://doc.qt.io/qt-6/qt-add-executable.html#target-creation
 else()
     if(ANDROID)
-        add_library(GameOfLife SHARED
-            ${PROJECT_SOURCES}
-        )
-# Define properties for Android with Qt 5 after find_package() calls as:
-#    set(ANDROID_PACKAGE_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/android")
+        add_library(GameOfLife SHARED ${PROJECT_SOURCES})
     else()
-        add_executable(GameOfLife
-            ${PROJECT_SOURCES}
-        )
+        add_executable(GameOfLife ${PROJECT_SOURCES})
     endif()
 endif()
 
-target_link_libraries(GameOfLife PRIVATE Qt${QT_VERSION_MAJOR}::Widgets)
+# Link the main application with the core library
+target_link_libraries(GameOfLife PRIVATE Qt${QT_VERSION_MAJOR}::Widgets GameOfLifeCore)
 
 # Qt for iOS sets MACOSX_BUNDLE_GUI_IDENTIFIER automatically since Qt 6.1.
 # If you are developing for iOS or macOS you should consider setting an
@@ -77,5 +77,7 @@ install(TARGETS GameOfLife
 if(QT_VERSION_MAJOR EQUAL 6)
     qt_finalize_executable(GameOfLife)
 endif()
+
+# Add subdirectories for tests
 add_subdirectory(WorldTests)
 add_subdirectory(SharkTests)

--- a/SharkTests/CMakeLists.txt
+++ b/SharkTests/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(shark LANGUAGES CXX)
+project(sharktests LANGUAGES CXX)
 
 enable_testing()
 
@@ -14,18 +14,11 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-set(SOURCES
-    ../fish.h ../fish.cpp
-    ../shark.h ../shark.cpp
-    ../world.h ../world.cpp
-    ../creature.h ../creature.cpp
-    ../cell.h ../cell.cpp
-    ../creatureType.h
-    ../creaturefactory.h ../creaturefactory.cpp
+add_executable(sharktests
+    test_shark.cpp
 )
 
-add_executable(sharktests ${SOURCES} test_shark.cpp)
+# Link the core library and Qt Test framework
+target_link_libraries(sharktests PRIVATE GameOfLifeCore Qt${QT_VERSION_MAJOR}::Test)
+
 add_test(NAME sharktests COMMAND sharktests)
-
-target_link_libraries(sharktests PRIVATE Qt${QT_VERSION_MAJOR}::Test)
-

--- a/WorldTests/CMakeLists.txt
+++ b/WorldTests/CMakeLists.txt
@@ -14,19 +14,11 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-set(SOURCES
-    ../fish.h ../fish.cpp
-    ../shark.h ../shark.cpp
-    ../world.h ../world.cpp
-    ../creature.h ../creature.cpp
-    ../cell.h ../cell.cpp
-    ../creatureType.h
-    ../creaturefactory.h ../creaturefactory.cpp
-)
-
 add_executable(worldtests
-    ${SOURCES}
     test_world.cpp
 )
+
+# Link the core library and Qt Test framework
+target_link_libraries(worldtests PRIVATE GameOfLifeCore Qt${QT_VERSION_MAJOR}::Test)
+
 add_test(NAME worldtests COMMAND worldtests)
-target_link_libraries(worldtests PRIVATE Qt${QT_VERSION_MAJOR}::Test)


### PR DESCRIPTION
Prompt I used for Copilot:
update my CMAkeLists.txt structure so that the core cpp files are built to a static library and then this static library is used for SharkTests and WorldTests

Answer:
To refactor your CMakeLists.txt structure so that the core C++ files are built into a static library and then linked to both SharkTests and WorldTests, you can follow this updated structure: