### PR TITLE
Added a resource file for the images making code run in Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)
     qt_add_executable(GameOfLife
         MANUAL_FINALIZATION
         ${PROJECT_SOURCES}
+        resources.qrc
     )
 else()
     if(ANDROID)

--- a/fish.cpp
+++ b/fish.cpp
@@ -15,11 +15,12 @@ std::string Fish::getResource()
 {
     std::array<std::string, 1> resources
         {
-            "/home/luismi/Documents/repos/GameOfLife/resources/fish.jpg",
-            //"/home/luismi/Documents/repos/GameOfLife/resources/fish1.jpg",
-            // "/home/luismi/Documents/repos/GameOfLife/resources/fish2.jpg",
-            // "/home/luismi/Documents/repos/GameOfLife/resources/fish3.jpg",
-            // "/home/luismi/Documents/repos/GameOfLife/resources/fish4.jpg"
+            ":/fish/fish-default",
+            // uncomment as many lines from below as different variations of the creature is desired
+            //":/fish/fish1",
+            // ":/fish/fish2",
+            // ":/fish/fish3",
+            // ":/fish/fish4"
         };
 
     // Generate a random number between 0 and 3

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -44,7 +44,7 @@ MainWindow::MainWindow(QWidget *parent)
 
 void MainWindow::renderWorld()
 {
-    QPixmap pixmapWater("/home/luismi/Documents/repos/GameOfLife/resources/water.jpg");
+    QPixmap pixmapWater(":/water/water-default");
 
     int rows = m_world.rowCount();
     int cols = m_world.colCount();

--- a/resources.qrc
+++ b/resources.qrc
@@ -1,0 +1,19 @@
+<RCC>
+    <qresource prefix="/sharks">
+        <file alias="shark-default">resources/shark.jpg</file>
+        <file alias="shark1">resources/shark1.jpg</file>
+        <file alias="shark2">resources/shark2.jpg</file>
+        <file alias="shark3">resources/shark3.jpg</file>
+        <file alias="shark4">resources/shark4.jpg</file>
+    </qresource>
+    <qresource prefix="/fish">
+        <file alias="fish-default">resources/fish.jpg</file>
+        <file alias="fish1">resources/fish1.jpg</file>
+        <file alias="fish2">resources/fish2.jpg</file>
+        <file alias="fish3">resources/fish3.jpg</file>
+        <file alias="fish4">resources/fish4.jpg</file>
+    </qresource>
+    <qresource prefix="/water">
+        <file alias="water-default">resources/water.jpg</file>
+    </qresource>
+</RCC>

--- a/shark.cpp
+++ b/shark.cpp
@@ -14,11 +14,12 @@ std::string Shark::getResource()
 {
     std::array<std::string, 1> resources
     {
-        "/home/luismi/Documents/repos/GameOfLife/resources/shark.jpg",
-        //"/home/luismi/Documents/repos/GameOfLife/resources/shark1.jpg",
-        //"/home/luismi/Documents/repos/GameOfLife/resources/shark2.jpg",
-        //"/home/luismi/Documents/repos/GameOfLife/resources/shark3.jpg",
-        //"/home/luismi/Documents/repos/GameOfLife/resources/shark4.jpg",
+        ":/sharks/shark-default",
+        // uncomment as many lines from below as different variations of the creature is desired
+        //":/sharks/shark1",
+        //":/sharks/shark2",
+        //":/sharks/shark3",
+        //":/sharks/shark4",
     };
 
     // Generate a random number between 0 and 3


### PR DESCRIPTION
This was the only change I needed to make in the codebase to make the code that was originally built in Linux work in Windows!  The original paths referenced absolute paths the filesystem in my Linux box.  By using a resource file, this now works cross-platform